### PR TITLE
remove sudo key - bye!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 jobs:
   include:
     - stage: unit tests


### PR DESCRIPTION
Travis CI uses a single linux infrastructure https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration